### PR TITLE
Implement shared state handling, menubar improvements

### DIFF
--- a/election-portal/app/election-breakdown/page.tsx
+++ b/election-portal/app/election-breakdown/page.tsx
@@ -43,17 +43,7 @@ export default function Election_Breakdown_Page() {
           {state.drawMode && <Canvas />}
 
           {/* Needs to be topmost during content screens */}
-          <Menubar
-            page={"test"}
-            setCurrentPage={stringTest}
-            exit={toggleBanner}
-            availableBreakdowns={["asdf", "asdf2", "asdf3", "asdf4"]}
-            breakdownSwitch={stringTest}
-            availableYears={[1, 2, 3]}
-            yearSwitch={numTest}
-            isVisible={isBannerVisible}
-            toggleVisibility={toggleBanner}
-          />
+          <Menubar />
 
           {/* Future homepage topmost element */}
         </div>

--- a/election-portal/app/election-breakdown/page.tsx
+++ b/election-portal/app/election-breakdown/page.tsx
@@ -12,8 +12,7 @@ import Canvas from "../modules/canvas/canvas";
 
 export default function Election_Breakdown_Page() {
   const [isBannerVisible, setIsBannerVisible] = useState<boolean>(true);
-  const [drawMode, setDrawMode] = useState<boolean>(false);
-
+  const state = useSharedState().state;
   const toggleBanner = () => {
     setIsBannerVisible(!isBannerVisible);
   };
@@ -24,11 +23,6 @@ export default function Election_Breakdown_Page() {
 
   const numTest = (test: number) => {
     console.log(test);
-  }
-
-  // If toggleDraw is true then we need to block mouse input to everything except Rightbar
-  const toggleDraw = () => {
-    setDrawMode(!drawMode);
   };
 
   return (
@@ -46,15 +40,13 @@ export default function Election_Breakdown_Page() {
             toggleVisibility={toggleBanner}
           />
 
-          {drawMode && <Canvas />}
+          {state.drawMode && <Canvas />}
 
           {/* Needs to be topmost during content screens */}
           <Menubar
             page={"test"}
             setCurrentPage={stringTest}
             exit={toggleBanner}
-            drawMode={drawMode}
-            toggleDraw={toggleDraw}
             availableBreakdowns={["asdf", "asdf2", "asdf3", "asdf4"]}
             breakdownSwitch={stringTest}
             availableYears={[1, 2, 3]}

--- a/election-portal/app/election-breakdown/page.tsx
+++ b/election-portal/app/election-breakdown/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 import React, { useState } from "react";
+import { useSharedState } from "../sharedContext";
 
 import Head from "next/head";
 import Image from "next/image";

--- a/election-portal/app/layout.tsx
+++ b/election-portal/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import localFont from "next/font/local";
+import { SharedStateProvider } from "./sharedContext";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -14,11 +15,13 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <head> {/* Needs to be fixed */}
+      <head>
         <link rel="stylesheet" href="https:[[use.typekit.net/dze2nzm.css"></link>
       </head>
       <body>
-        {children}
+        <SharedStateProvider>
+          {children}
+        </SharedStateProvider>
       </body>
     </html>
   );

--- a/election-portal/app/modules/menubar/menu-buttons/draw-button.tsx
+++ b/election-portal/app/modules/menubar/menu-buttons/draw-button.tsx
@@ -1,34 +1,34 @@
+import { useSharedState } from "@/app/sharedContext";
 import styles from "./draw-button.module.css";
 import Image, { StaticImageData } from "next/image";
 import { useRouter } from "next/navigation";
 import React, { useState, useRef, useEffect } from "react";
 import { MdDraw } from "react-icons/md";
 
+const DrawButton: React.FC = () => {
+  const state = useSharedState().state;
 
-interface ExitButtonProps {
-    drawMode: boolean;
-    toggleDraw: () => void;
-}
-
-
-const DrawButton: React.FC<ExitButtonProps> = (props: ExitButtonProps) => {
-
-
-    return (
-        <div>
-        <button onClick={props.toggleDraw} 
-            className={styles.button}>
-            <div className={`${styles.button_container} ${props.drawMode ? styles.button_container_active : ""}`}>
-            <div className={styles.button_col}>
-                <div className={styles.button_icon_container}>
-                    <MdDraw 
-                        className={`${styles.draw_icon} ${props.drawMode ? styles.draw_icon_active : ""}`}
-                        title="Toggle Draw" />
-                </div>
+  return (
+    <div>
+      <button onClick={state.toggleDraw} className={styles.button}>
+        <div
+          className={`${styles.button_container} ${
+            state.drawMode ? styles.button_container_active : ""
+          }`}
+        >
+          <div className={styles.button_col}>
+            <div className={styles.button_icon_container}>
+              <MdDraw
+                className={`${styles.draw_icon} ${
+                  state.drawMode ? styles.draw_icon_active : ""
+                }`}
+                title="Toggle Draw"
+              />
             </div>
-            </div>
-        </button>
+          </div>
         </div>
+      </button>
+    </div>
   );
 };
 

--- a/election-portal/app/modules/menubar/menubar.css
+++ b/election-portal/app/modules/menubar/menubar.css
@@ -57,7 +57,6 @@
     margin-top: 0.5rem;
     margin-bottom: 0.5rem;
     color: white;
-    opacity: 0.75;
     font-size: 1.5rem;
     cursor: pointer;
 }

--- a/election-portal/app/modules/menubar/menubar.tsx
+++ b/election-portal/app/modules/menubar/menubar.tsx
@@ -1,64 +1,108 @@
 "use client";
 
 import React from 'react';
+import { useSharedState } from "../../sharedContext";
+import { RaceType, Year } from "../../../types/SharedInfoType";
+
 import './menubar.css';
 import HomeButton from './menu-buttons/home-button';
 import ExitButton from './menu-buttons/exit-button';
 import DrawButton from './menu-buttons/draw-button';
 import { useRouter } from "next/navigation";
 
-type MenubarProps = {
-  page: string;
-  setCurrentPage: (page: string) => void;
-  exit: () => void;
-  drawMode: boolean;
-  toggleDraw: () => void;
-  availableBreakdowns: string[];
-  breakdownSwitch: (breakdown: string) => void;
-  availableYears: number[];
-  yearSwitch: (year: number) => void;
-  isVisible: boolean;
-  toggleVisibility: () => void;
-};
 
-const Menubar: React.FC<MenubarProps> = 
-  ({  page, setCurrentPage, exit, drawMode, toggleDraw, availableBreakdowns, breakdownSwitch,
-      availableYears, yearSwitch, isVisible, toggleVisibility }) => {
+const breakdownToString = (breakdown: RaceType, currentBreakdown: RaceType): React.ReactNode => {
+  let str: string = "";
+  const selected: boolean = breakdown === currentBreakdown;
+  switch (breakdown) {
+    case RaceType.Presidential:
+      str = "Pres.";
+      break;
+    case RaceType.Senate:
+      str = "Sen."
+      break;
+    case RaceType.Gubernatorial:
+      str = "Gub.";
+      break;
+    case RaceType.House:
+      str = "Hse.";
+      break;
+    default:
+      str = "Unk.";
+      break;
+  }
+  return (
+    <span style={{ color: selected ? '#ffffff' : "#dddddd", textShadow: selected ? '0 0 10px rgba(255,255,255,0.5)' : 'none' }}>
+      {str}
+    </span>
+  )
+}
+
+const yearToString = (year: Year, currentYear: Year): React.ReactNode => {
+  let str = "";
+  const selected: boolean = year === currentYear;
+  switch (year) {
+    case Year.TwentyFour:
+      str = "2024";
+      break;
+    case Year.TwentyTwo:
+      str = "2022";
+      break;
+    case Year.Twenty:
+      str = "2020";
+      break;
+    case Year.Eighteen:
+      str = "2018";
+      break;
+    case Year.Sixteen:
+      str = "2016";
+      break;
+    default:
+      str = "Unk.";
+      break;
+  }
+  return (
+    <span style={{ color: selected ? '#ffffff' : "#dddddd", textShadow: selected ? '0 0 10px rgba(255,255,255,0.5)' : 'none' }}>
+      {str}
+    </span>
+  )
+}
+
+
+const Menubar: React.FC = () => {
+
+  const state = useSharedState().state;
 
   return (
     <div className="rightbar">
       <div className="contents">
-        {isVisible && (
-          <>
-            <div className="menu-buttons">
-              <HomeButton currentPage={page} setCurrentPage={setCurrentPage} />
-              <br></br>
-              <ExitButton currentPage={page} setCurrentPage={setCurrentPage}/>
-              <br>{/* better way to do this (.menu-buttons in css?))*/}</br>
-              <DrawButton drawMode={drawMode} toggleDraw={toggleDraw}/>
-            </div>
+        <div className="menu-buttons">
+          <HomeButton currentPage={state.page} setCurrentPage={state.setCurrentPage} />
+          <br></br>
+          <ExitButton currentPage={state.page} setCurrentPage={state.setCurrentPage}/>
+          <br>{/* better way to do this (.menu-buttons in css?))*/}</br>
+          <DrawButton drawMode={state.drawMode} toggleDraw={state.toggleDraw}/>
+        </div>
 
-            <div className="divider"></div>
+        <div className="divider"></div>
 
-            <div className="breakdowns">
-              {availableBreakdowns.map((breakdown, index) => (
-                <button className="breakdown" key={index} onClick={() => breakdownSwitch(breakdown)}>
-                  {breakdown}
-                </button>
-              ))}
-            </div>
+        <div className="breakdowns">
+          {state.availableBreakdowns.map((breakdown, index) => (
+            <button className="breakdown" key={index} onClick={() => state.breakdownSwitch(breakdown)}>
+              {breakdownToString(breakdown, state.breakdown)}
+            </button>
+          ))}
+        </div>
 
-            <div className="divider"></div>
+        <div className="divider"></div>
 
-            <div className="years">
-              {availableYears.map((year, index) => (
-                <button className="year" key={index} onClick={() => yearSwitch(year)}>
-                  {year}
-                </button>
-              ))}
-            </div>
-          </>
-        )}
+        <div className="years">
+          {state.availableYears.map((year, index) => (
+            <button className="year" key={index} onClick={() => state.yearSwitch(year)}>
+              {yearToString(year, state.year)}
+            </button>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/election-portal/app/modules/menubar/menubar.tsx
+++ b/election-portal/app/modules/menubar/menubar.tsx
@@ -1,17 +1,19 @@
 "use client";
 
-import React from 'react';
+import React from "react";
 import { useSharedState } from "../../sharedContext";
 import { RaceType, Year } from "../../../types/SharedInfoType";
 
-import './menubar.css';
-import HomeButton from './menu-buttons/home-button';
-import ExitButton from './menu-buttons/exit-button';
-import DrawButton from './menu-buttons/draw-button';
+import "./menubar.css";
+import HomeButton from "./menu-buttons/home-button";
+import ExitButton from "./menu-buttons/exit-button";
+import DrawButton from "./menu-buttons/draw-button";
 import { useRouter } from "next/navigation";
 
-
-const breakdownToString = (breakdown: RaceType, currentBreakdown: RaceType): React.ReactNode => {
+const breakdownToString = (
+  breakdown: RaceType,
+  currentBreakdown: RaceType
+): React.ReactNode => {
   let str: string = "";
   const selected: boolean = breakdown === currentBreakdown;
   switch (breakdown) {
@@ -19,7 +21,7 @@ const breakdownToString = (breakdown: RaceType, currentBreakdown: RaceType): Rea
       str = "Pres.";
       break;
     case RaceType.Senate:
-      str = "Sen."
+      str = "Sen.";
       break;
     case RaceType.Gubernatorial:
       str = "Gub.";
@@ -32,11 +34,16 @@ const breakdownToString = (breakdown: RaceType, currentBreakdown: RaceType): Rea
       break;
   }
   return (
-    <span style={{ color: selected ? '#ffffff' : "#dddddd", textShadow: selected ? '0 0 10px rgba(255,255,255,0.5)' : 'none' }}>
+    <span
+      style={{
+        color: selected ? "#ffffff" : "#dddddd",
+        textShadow: selected ? "0 0 10px rgba(255,255,255,0.5)" : "none",
+      }}
+    >
       {str}
     </span>
-  )
-}
+  );
+};
 
 const yearToString = (year: Year, currentYear: Year): React.ReactNode => {
   let str = "";
@@ -62,33 +69,46 @@ const yearToString = (year: Year, currentYear: Year): React.ReactNode => {
       break;
   }
   return (
-    <span style={{ color: selected ? '#ffffff' : "#dddddd", textShadow: selected ? '0 0 10px rgba(255,255,255,0.5)' : 'none' }}>
+    <span
+      style={{
+        color: selected ? "#ffffff" : "#dddddd",
+        textShadow: selected ? "0 0 10px rgba(255,255,255,0.5)" : "none",
+      }}
+    >
       {str}
     </span>
-  )
-}
-
+  );
+};
 
 const Menubar: React.FC = () => {
-
   const state = useSharedState().state;
 
   return (
     <div className="rightbar">
       <div className="contents">
         <div className="menu-buttons">
-          <HomeButton currentPage={state.page} setCurrentPage={state.setCurrentPage} />
+          <HomeButton
+            currentPage={state.page}
+            setCurrentPage={state.setCurrentPage}
+          />
           <br></br>
-          <ExitButton currentPage={state.page} setCurrentPage={state.setCurrentPage}/>
+          <ExitButton
+            currentPage={state.page}
+            setCurrentPage={state.setCurrentPage}
+          />
           <br>{/* better way to do this (.menu-buttons in css?))*/}</br>
-          <DrawButton drawMode={state.drawMode} toggleDraw={state.toggleDraw}/>
+          <DrawButton />
         </div>
 
         <div className="divider"></div>
 
         <div className="breakdowns">
           {state.availableBreakdowns.map((breakdown, index) => (
-            <button className="breakdown" key={index} onClick={() => state.breakdownSwitch(breakdown)}>
+            <button
+              className="breakdown"
+              key={index}
+              onClick={() => state.breakdownSwitch(breakdown)}
+            >
               {breakdownToString(breakdown, state.breakdown)}
             </button>
           ))}
@@ -98,7 +118,11 @@ const Menubar: React.FC = () => {
 
         <div className="years">
           {state.availableYears.map((year, index) => (
-            <button className="year" key={index} onClick={() => state.yearSwitch(year)}>
+            <button
+              className="year"
+              key={index}
+              onClick={() => state.yearSwitch(year)}
+            >
               {yearToString(year, state.year)}
             </button>
           ))}

--- a/election-portal/app/sharedContext.tsx
+++ b/election-portal/app/sharedContext.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+import { useRouter } from "next/navigation";
+import { SharedInfo, State, Year, RaceType } from '../types/SharedInfoType';
+
+interface SharedStateContextProps {
+    state: SharedInfo;
+}
+
+const SharedStateContext = createContext<SharedStateContextProps | undefined>(undefined);
+
+export const SharedStateProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+    const router = useRouter();
+
+    const [page, setPage] = useState<string>("/");
+    const setCurrentPage = (page: string) => {
+        setPage(page);
+        router.push(page);
+    }
+    const [view, setView] = useState<State>(State.National);
+    const [level, setLevel] = useState<"county" | "state" | "national">("national");
+    const exitLevel = () => {
+        if (level === "county") {
+            setLevel("state");
+        } else if (level === "state") {
+            setLevel("national");
+        }
+    };
+    const [drawMode, setDrawMode] = useState<boolean>(false);
+    const toggleDraw = () => setDrawMode(!drawMode);
+    const [breakdown, setBreakdown] = useState<RaceType>(RaceType.Presidential);
+    const [availableBreakdowns, setAvailableBreakdowns] = useState<RaceType[]>([
+        RaceType.Presidential,
+        RaceType.Senate,
+        RaceType.Gubernatorial,
+        RaceType.House
+    ]);
+    const breakdownSwitch = (breakdown: RaceType) => {
+        if (availableBreakdowns.includes(breakdown)) {
+            setBreakdown(breakdown);
+        }
+    };
+    const [year, setYear] = useState<Year>(Year.Twenty);
+    const [availableYears, setAvailableYears] = useState<Year[]>([
+        Year.TwentyTwo,
+        Year.Twenty,
+        Year.Eighteen,
+        Year.Sixteen,
+    ]);
+    const yearSwitch = (year: Year) => {
+        if (availableYears.includes(year)) {
+            setYear(year);
+        }
+    };
+
+    const state: SharedInfo = {
+        page,
+        setCurrentPage,
+        view,
+        setView,
+        level,
+        exitLevel,
+        drawMode,
+        toggleDraw,
+        breakdown,
+        availableBreakdowns,
+        setAvailableBreakdowns,
+        breakdownSwitch,
+        year,
+        availableYears,
+        setAvailableYears,
+        yearSwitch,
+    };
+
+
+    return (
+        <SharedStateContext.Provider value={{ state }}>
+            {children}
+        </SharedStateContext.Provider>
+    );
+};
+
+export const useSharedState = (): SharedStateContextProps => {
+    const context = useContext(SharedStateContext);
+    if (!context) {
+        throw new Error('useSharedState must be used within a SharedStateProvider');
+    }
+    return context;
+};

--- a/election-portal/types/SharedInfoType.ts
+++ b/election-portal/types/SharedInfoType.ts
@@ -1,0 +1,24 @@
+import { RaceType } from "./RaceType";
+import { Year } from "./Year";
+import { State } from "./State";
+
+export type SharedInfo = {
+    page: string;
+    setCurrentPage: (page: string) => void;
+    view: State;
+    setView: (view: State) => void;
+    level: "county" | "state" | "national";
+    exitLevel: () => void;
+    drawMode: boolean;
+    toggleDraw: () => void;
+    breakdown: RaceType;
+    availableBreakdowns: RaceType[];
+    setAvailableBreakdowns: (breakdowns: RaceType[]) => void;
+    breakdownSwitch: (breakdown: RaceType) => void;
+    year: Year;
+    availableYears: Year[];
+    setAvailableYears: (years: Year[]) => void;
+    yearSwitch: (year: Year) => void;
+};
+
+export { RaceType, Year, State };


### PR DESCRIPTION
menubar changes: selected breakdowns/years glow

shared state:
- react shared context in sharedContext.tsx
  - should contain all info for map region display (but not any specifics)
  - contains all menubar information

I was thinking it would be prettier for the three map components to use the shared context and then handle any specifics (like exit poll data) within the individual components

something like this would ideally allow map region + menubar state to persist between page switches. each component will have to parse the state however they see fit (for example:)
- menubar.tsx parses RaceType and Year into reactnodes (strings) 
- whereas the national map component may parse it to search the csv file